### PR TITLE
Bug #522: Skip tests by default

### DIFF
--- a/opssat-package/copy.xml
+++ b/opssat-package/copy.xml
@@ -31,4 +31,22 @@
     </copy>
     <chmod dir="${esa.nmf.mission.opssat.assembly.outputdir}" perm="ugo+rx" includes="**/*.sh"/>
   </target>
+
+  <target name="copyExp">   
+    <copy todir="${esa.nmf.mission.opssat.assembly.outputdir}/experimenter-package/home/${expId}/">
+      <fileset dir="${basedir}/src/main/resources/space-common"/>
+      <fileset dir="${basedir}/src/main/resources/space-app-root"/>
+      <filterset>
+        <filter token="MAIN_CLASS_NAME" value="esa.mo.nmf.apps.PayloadsTestApp"/>
+        <filter token="APID" value="1504"/>
+        <filter token="NMF_HOME" value="`cd ../nmf > /dev/null; pwd`"/>
+        <filter token="NMF_LIB" value="`cd ../nmf/lib > /dev/null; pwd`/*"/>
+      </filterset>
+      <firstmatchmapper>
+        <globmapper from="startscript.sh" to="start_${expId}.sh"/>
+        <globmapper from="*" to="*"/>
+      </firstmatchmapper>
+    </copy>
+    <chmod dir="${esa.nmf.mission.opssat.assembly.outputdir}" perm="ugo+rx" includes="**/*.sh"/>
+  </target>
 </project>

--- a/opssat-package/copy.xml
+++ b/opssat-package/copy.xml
@@ -15,12 +15,17 @@
         <globmapper from="*" to="*"/>
       </firstmatchmapper>
     </copy>
+    <exec executable="expr" outputproperty="apid">
+      <arg value="1024"/>
+      <arg value="+"/>
+      <arg value="480"/>
+    </exec>
     <copy todir="${esa.nmf.mission.opssat.assembly.outputdir}/home/payloads-test">
       <fileset dir="${basedir}/src/main/resources/space-common"/>
       <fileset dir="${basedir}/src/main/resources/space-app-root"/>
       <filterset>
         <filter token="MAIN_CLASS_NAME" value="esa.mo.nmf.apps.PayloadsTestApp"/>
-        <filter token="APID" value="1504"/>
+        <filter token="APID" value="${apid}"/>
         <filter token="NMF_HOME" value="`cd ../nmf > /dev/null; pwd`"/>
         <filter token="NMF_LIB" value="`cd ../nmf/lib > /dev/null; pwd`/*"/>
       </filterset>
@@ -32,18 +37,23 @@
     <chmod dir="${esa.nmf.mission.opssat.assembly.outputdir}" perm="ugo+rx" includes="**/*.sh"/>
   </target>
 
-  <target name="copyExp">   
-    <copy todir="${esa.nmf.mission.opssat.assembly.outputdir}/experimenter-package/home/${expId}/">
+  <target name="copyExp">
+    <exec executable="expr" outputproperty="expApid">
+      <arg value="1024"/>
+      <arg value="+"/>
+      <arg value="${expId}"/>
+    </exec>   
+    <copy todir="${esa.nmf.mission.opssat.assembly.outputdir}/experimenter-package/home/exp${expId}/">
       <fileset dir="${basedir}/src/main/resources/space-common"/>
       <fileset dir="${basedir}/src/main/resources/space-app-root"/>
       <filterset>
         <filter token="MAIN_CLASS_NAME" value="esa.mo.nmf.apps.PayloadsTestApp"/>
-        <filter token="APID" value="1504"/>
+        <filter token="APID" value="${expApid}"/>
         <filter token="NMF_HOME" value="`cd ../nmf > /dev/null; pwd`"/>
         <filter token="NMF_LIB" value="`cd ../nmf/lib > /dev/null; pwd`/*"/>
       </filterset>
       <firstmatchmapper>
-        <globmapper from="startscript.sh" to="start_${expId}.sh"/>
+        <globmapper from="startscript.sh" to="start_exp${expId}.sh"/>
         <globmapper from="*" to="*"/>
       </firstmatchmapper>
     </copy>

--- a/opssat-package/pom.xml
+++ b/opssat-package/pom.xml
@@ -100,14 +100,14 @@
       <id>exp</id>
       <properties>
         <isExp>true</isExp>
-        <expId>exp1337</expId>
+        <expId>000</expId>
         <expVersion>2.0.0-SNAPSHOT</expVersion>
       </properties>
       <dependencies>
         <dependency>
           <groupId>int.esa.nmf.sdk.examples.space</groupId>
           <artifactId>publish-clock</artifactId>
-          <version>${project.version}</version>
+          <version>${expVersion}</version>
         </dependency>
       </dependencies>
       <build>
@@ -133,7 +133,7 @@
                       <!-- Do not change this -->
                       <type>jar</type>
                       <overWrite>true</overWrite>
-                      <outputDirectory>${esa.nmf.mission.opssat.assembly.outputdir}/experimenter-package/home/${expId}/lib/</outputDirectory>
+                      <outputDirectory>${esa.nmf.mission.opssat.assembly.outputdir}/experimenter-package/home/exp${expId}/lib/</outputDirectory>
                     </artifactItem>
                   </artifactItems>
                 </configuration>

--- a/opssat-package/pom.xml
+++ b/opssat-package/pom.xml
@@ -96,6 +96,53 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>exp</id>
+      <properties>
+        <isExp>true</isExp>
+        <expId>exp1337</expId>
+        <expVersion>2.0.0-SNAPSHOT</expVersion>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>int.esa.nmf.sdk.examples.space</groupId>
+          <artifactId>publish-clock</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>expLib</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <!-- Change the following 3 lines to match the information of your app -->
+                      <groupId>int.esa.nmf.sdk.examples.space</groupId>
+                      <artifactId>payloads-test</artifactId>
+                      <version>2.0.0-SNAPSHOT</version>
+                      <!-- Do not change this -->
+                      <type>jar</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${esa.nmf.mission.opssat.assembly.outputdir}/experimenter-package/home/${expId}/lib/</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
   <dependencies>
     <!-- NOTE: Imprecise version resolution using ${esa.nmf.version-qualifier} cannot be used here,
@@ -217,6 +264,18 @@
             <configuration>
               <target if="${isGround}">
                 <ant antfile="copy_ground.xml" target="copyfiles"/>
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>experimenter</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target if="${isExp}">
+                <ant antfile="copy.xml" target="copyExp"/>
               </target>
             </configuration>
           </execution>

--- a/transport/dlr-malspp/encoding-opssat/pom.xml
+++ b/transport/dlr-malspp/encoding-opssat/pom.xml
@@ -8,7 +8,9 @@
         <version>1.0.1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
-
+    <properties>
+      <skipTests>true</skipTests>
+    </properties>
     <artifactId>malspp-encoding-opssat</artifactId>
     <version>1.0.1-FC</version>
     <packaging>jar</packaging>

--- a/transport/dlr-malspp/encoding/pom.xml
+++ b/transport/dlr-malspp/encoding/pom.xml
@@ -16,6 +16,11 @@
     <name>DLR MO MAL/SPP Encoding</name>
     <description>DLR implementation of CCSDS MO MAL/SPP Binding, encoding part</description>
     <url>http://www.dlr.de</url>
+
+    <properties>
+      <skipTests>true</skipTests>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>int.esa.ccsds.mo</groupId>

--- a/transport/dlr-malspp/transport/pom.xml
+++ b/transport/dlr-malspp/transport/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>malspp-transport</artifactId>
     <version>1.0.1-FC</version>
     <packaging>jar</packaging>
+    
+    <properties>
+      <skipTests>true</skipTests>
+    </properties>
 
     <name>DLR MO MAL/SPP Transport Layer</name>
     <description>DLR implementation of CCSDS MO MAL/SPP Binding, transport part</description>


### PR DESCRIPTION
Speed up build by default skipping the tests, as most users don't care about these, anyways.

The tests can be re-enabled by providing `-DskipTests=false` to the command line when invoking `mvn install`.