### PR TITLE
Apps launcher update

### DIFF
--- a/opssat-package/copy.xml
+++ b/opssat-package/copy.xml
@@ -9,6 +9,7 @@
         <filter token="APPS_DIR" value="../.."/>
         <filter token="NMF_HOME" value="`cd .. > /dev/null; pwd`"/>
         <filter token="NMF_LIB" value="`cd ../lib > /dev/null; pwd`/*"/>
+        <filter token="USER" value="root"/>
       </filterset>
       <firstmatchmapper>
         <globmapper from="startscript.sh" to="supervisor.sh"/>
@@ -28,6 +29,7 @@
         <filter token="APID" value="${apid}"/>
         <filter token="NMF_HOME" value="`cd ../nmf > /dev/null; pwd`"/>
         <filter token="NMF_LIB" value="`cd ../nmf/lib > /dev/null; pwd`/*"/>
+        <filter token="USER" value="root"/>
       </filterset>
       <firstmatchmapper>
         <globmapper from="startscript.sh" to="start_payloads-test.sh"/>
@@ -51,6 +53,7 @@
         <filter token="APID" value="${expApid}"/>
         <filter token="NMF_HOME" value="`cd ../nmf > /dev/null; pwd`"/>
         <filter token="NMF_LIB" value="`cd ../nmf/lib > /dev/null; pwd`/*"/>
+        <filter token="USER" value="exp${expId}"/>
       </filterset>
       <firstmatchmapper>
         <globmapper from="startscript.sh" to="start_exp${expId}.sh"/>

--- a/opssat-package/nmf-package/control/control
+++ b/opssat-package/nmf-package/control/control
@@ -1,4 +1,4 @@
-Package: nmf_package
+Package: nmf-ops-sat
 Version: @VERSION@
 Architecture: sepp
 Maintainer: ESOC

--- a/opssat-package/nmf-package/control/control
+++ b/opssat-package/nmf-package/control/control
@@ -1,4 +1,4 @@
-Package: nmf-package
+Package: nmf_package
 Version: @VERSION@
 Architecture: sepp
 Maintainer: ESOC

--- a/opssat-package/pom.xml
+++ b/opssat-package/pom.xml
@@ -320,7 +320,7 @@
                   <arg value="--group=0"/>
                   <arg value="--owner=0"/>
                   <arg value="-cf"/>
-                  <arg value="../nmf_package_${project.version}.ipk"/>
+                  <arg value="../nmf-ops-sat_${project.version}.ipk"/>
                   <arg value="./debian-binary"/>
                   <arg value="./control.tar.gz"/>
                   <arg value="./data.tar.gz"/>

--- a/opssat-package/pom.xml
+++ b/opssat-package/pom.xml
@@ -320,7 +320,7 @@
                   <arg value="--group=0"/>
                   <arg value="--owner=0"/>
                   <arg value="-cf"/>
-                  <arg value="../nmf-package.ipk"/>
+                  <arg value="../nmf_package_${project.version}.ipk"/>
                   <arg value="./debian-binary"/>
                   <arg value="./control.tar.gz"/>
                   <arg value="./data.tar.gz"/>

--- a/opssat-package/src/main/resources/space-app-root/provider.properties
+++ b/opssat-package/src/main/resources/space-app-root/provider.properties
@@ -1,6 +1,7 @@
 # MO App configurations
 helpertools.configurations.OrganizationName=esa
 helpertools.configurations.provider.app.category=NMF_App
+helpertools.configurations.provider.app.user=@USER@
 
 # NanoSat MO Framework transport configuration
 helpertools.configurations.provider.transportfilepath=transport.properties


### PR DESCRIPTION
This PR addresses Bug #330: Supervisor should not execute experiments as root.

This patch includes the updated provider.properties template and the updated Ant script. 

I further updated the IPK packaging to be consistent with FCT's NMF update procedure.